### PR TITLE
Switch OpenError to use std Error trait instead of deriving Fail

### DIFF
--- a/opener/Cargo.toml
+++ b/opener/Cargo.toml
@@ -13,8 +13,6 @@ appveyor = { repository = "Seeker14491/opener", branch = "master", service = "gi
 travis-ci = { repository = "Seeker14491/opener", branch = "master" }
 
 [dependencies]
-failure = "0.1.2"
-failure_derive = "0.1.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["shellapi"] }


### PR DESCRIPTION
Closes #2.

This PR makes `OpenError` implement `std::error::Error`, which I think is expected of most error types. It will help make opener easier to use in projects that don't use the failure crate.

Since failure was only used for setting the source of the `OpenError`, this is a pretty straightforward change.

This should _not_ be a breaking change since failure already blanket implements the `Fail` trait for everything implementing `std::error::Error`.

This change _may_ increase the minimum Rust version that opener requires, since `Error::source` was only stabilized in Rust 1.30. If this is a problem, I can change the PR to use the (now deprecated) `Error::cause` API which is functionally very similar.

This removes the explicit dependencies on `failure` and `failure_derive`, which should improve compilation times for consumers of `opener` that aren't otherwise using those libraries.