### PR TITLE
Add function to open files in system file manager

### DIFF
--- a/opener-bin/src/main.rs
+++ b/opener-bin/src/main.rs
@@ -16,9 +16,13 @@ struct Args {
     #[structopt(parse(from_os_str))]
     path: PathBuf,
 
-    /// Open the path with the `open_browser()` function instead of the `open` function
+    /// Open the path with the `open_browser()` function
     #[structopt(long = "browser")]
     browser: bool,
+
+    /// Open the path with the `open_in_file_manager()` function
+    #[structopt(long = "file-manager", conflicts_with("browser"))]
+    file_manager: bool,
 }
 
 fn main() {
@@ -26,6 +30,8 @@ fn main() {
 
     let open_result = if args.browser {
         opener::open_browser(&args.path)
+    } else if args.file_manager {
+        opener::open_in_file_manager(&args.path)
     } else {
         opener::open(&args.path)
     };

--- a/opener/src/lib.rs
+++ b/opener/src/lib.rs
@@ -124,7 +124,6 @@ where
     sys::open_in_file_manager(path.as_ref())
 }
 
-
 /// An error type representing the failure to open a path. Possibly returned by the [`open`]
 /// function.
 ///

--- a/opener/src/lib.rs
+++ b/opener/src/lib.rs
@@ -43,6 +43,7 @@ use crate::windows as sys;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter};
+use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
 use std::{env, io};
 
@@ -113,13 +114,13 @@ where
 ///
 /// - On Windows the `ShellExecuteW` Windows API function is used.
 /// - On Mac the system `open` command is used.
-/// - On Linux and other platforms,
-/// the file is opened in Nautilus
+/// - On Linux and other platforms, if the file is a directory,
+/// it is opened using xdg-open, otherwise nautilus.
 ///
 /// [`wslu`]: https://github.com/wslutilities/wslu/
 pub fn open_in_file_manager<P>(path: P) -> Result<(), OpenError>
 where
-    P: AsRef<OsStr>,
+    P: AsRef<Path>,
 {
     sys::open_in_file_manager(path.as_ref())
 }

--- a/opener/src/lib.rs
+++ b/opener/src/lib.rs
@@ -107,6 +107,24 @@ where
     }
 }
 
+/// Opens a file or link with the default system file manager.
+///
+/// ## Platform Implementation Details
+///
+/// - On Windows the `ShellExecuteW` Windows API function is used.
+/// - On Mac the system `open` command is used.
+/// - On Linux and other platforms,
+/// the file is opened in Nautilus
+///
+/// [`wslu`]: https://github.com/wslutilities/wslu/
+pub fn open_in_file_manager<P>(path: P) -> Result<(), OpenError>
+where
+    P: AsRef<OsStr>,
+{
+    sys::open_in_file_manager(path.as_ref())
+}
+
+
 /// An error type representing the failure to open a path. Possibly returned by the [`open`]
 /// function.
 ///

--- a/opener/src/linux_and_more.rs
+++ b/opener/src/linux_and_more.rs
@@ -16,9 +16,10 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
 
 pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
     Command::new("nautilus")
-    .arg("--select")
-    .arg(path.as_ref())
-    .spawn()?;
+        .arg("--select")
+        .arg(path)
+        .spawn()
+        .map_err(OpenError::Io)?;
     Ok(())
 }
 

--- a/opener/src/linux_and_more.rs
+++ b/opener/src/linux_and_more.rs
@@ -1,6 +1,7 @@
 use crate::OpenError;
 use std::ffi::OsStr;
 use std::io::Write;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::{fs, io};
 
@@ -14,13 +15,17 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
     }
 }
 
-pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
-    Command::new("nautilus")
-        .arg("--select")
-        .arg(path)
-        .spawn()
-        .map_err(OpenError::Io)?;
-    Ok(())
+pub(crate) fn open_in_file_manager(path: &Path) -> Result<(), OpenError> {
+    if path.is_dir() {
+        open(path.as_ref())
+    } else {
+        Command::new("nautilus")
+            .arg("--select")
+            .arg(path)
+            .spawn()
+            .map_err(OpenError::Io)?;
+        Ok(())
+    }
 }
 
 fn wsl_open(path: &OsStr) -> Result<(), OpenError> {

--- a/opener/src/linux_and_more.rs
+++ b/opener/src/linux_and_more.rs
@@ -16,10 +16,9 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
 }
 
 pub(crate) fn open_in_file_manager(path: &Path) -> Result<(), OpenError> {
-    let mut dbus_path = OsString::from("array:string:\"file://");
+    let mut dbus_path = OsString::from("array:string:file://");
     dbus_path.push(path.canonicalize().map_err(OpenError::Io)?);
-    dbus_path.push("\"");
-    let mut child = Command::new("dbus-send")
+    let child = Command::new("dbus-send")
         .arg("--session")
         .arg("--dest=org.freedesktop.FileManager1")
         .arg("--type=method_call")

--- a/opener/src/linux_and_more.rs
+++ b/opener/src/linux_and_more.rs
@@ -14,6 +14,14 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
     }
 }
 
+pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
+    Command::new("nautilus")
+    .arg("--select")
+    .arg(path.as_ref())
+    .spawn()?;
+    Ok(())
+}
+
 fn wsl_open(path: &OsStr) -> Result<(), OpenError> {
     let result = open_with_wslview(path);
     if let Ok(mut child) = result {

--- a/opener/src/macos.rs
+++ b/opener/src/macos.rs
@@ -1,5 +1,6 @@
 use crate::OpenError;
 use std::ffi::OsStr;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
@@ -14,7 +15,7 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
     crate::wait_child(&mut open, "open")
 }
 
-pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
+pub(crate) fn open_in_file_manager(path: &Path) -> Result<(), OpenError> {
     let mut open = Command::new("open")
         .arg("-R")
         .arg(path)

--- a/opener/src/macos.rs
+++ b/opener/src/macos.rs
@@ -13,3 +13,16 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
 
     crate::wait_child(&mut open, "open")
 }
+
+pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
+    let mut open = Command::new("open")
+        .arg("-R")
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(OpenError::Io)?;
+
+    crate::wait_child(&mut open, "open")
+}

--- a/opener/src/windows.rs
+++ b/opener/src/windows.rs
@@ -1,6 +1,7 @@
 use crate::OpenError;
 use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
 use std::{io, ptr};
 use winapi::ctypes::c_int;
 use winapi::um::shellapi::ShellExecuteW;
@@ -27,7 +28,7 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
     }
 }
 
-pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
+pub(crate) fn open_in_file_manager(path: &Path) -> Result<(), OpenError> {
     const SW_SHOW: c_int = 5;
 
     let mut select_path = OsString::from("/select,\"");

--- a/opener/src/windows.rs
+++ b/opener/src/windows.rs
@@ -32,7 +32,7 @@ pub(crate) fn open_in_file_manager(path: &OsStr) -> Result<(), OpenError> {
 
     let mut select_path = OsString::from("/select,\"");
     select_path.push(path);
-    select_path.push('"');
+    select_path.push("\"");
 
     let operation: Vec<u16> = OsStr::new("open\0").encode_wide().collect();
     let explorer = convert_path("explorer.exe".as_ref()).map_err(OpenError::Io)?;


### PR DESCRIPTION
I'd like to use opener to open files in my application, but I also need to be able to open files in a file manager. I have added an implementation for this on Windows, MacOS, and Linux (but not WSL). I think something like `explorer.exe /select,"path"` would work, but I had issues with Process mangling the string escaping.

The Windows implementation is based on [this answer from StackOverflow](https://stackoverflow.com/questions/15300999/open-windows-explorer-directory-select-a-specific-file-in-delphi), adapted to Rust.

The MacOS implementation is based on [this link](https://scriptingosx.com/2017/02/the-macos-open-command/), under the "Showing Files in Finder" subsection.

The Linux implementation uses dbus, though this only supports one or two file managers, based on [this answer from StackOverflow](https://unix.stackexchange.com/questions/364997/open-a-directory-in-the-default-file-manager-and-select-a-file).