### PR TITLE
 Make linux check for subprocess errors 

### DIFF
--- a/opener/src/linux_and_more.rs
+++ b/opener/src/linux_and_more.rs
@@ -20,17 +20,18 @@ fn wsl_open(path: &OsStr) -> Result<(), OpenError> {
         return crate::wait_child(&mut child, "wslview");
     }
 
-    open_with_system_xdg_open(path).map_err(OpenError::Io)?;
+    let mut open = open_with_system_xdg_open(path).map_err(OpenError::Io)?;
 
-    Ok(())
+    crate::wait_child(&mut open, "wslview")
 }
 
 fn non_wsl_open(path: &OsStr) -> Result<(), OpenError> {
-    if open_with_system_xdg_open(path).is_err() {
-        open_with_internal_xdg_open(path)?;
-    }
+    let mut open = match open_with_system_xdg_open(path) {
+        Err(_) => open_with_internal_xdg_open(path)?,
+        Ok(child) => child,
+    };
 
-    Ok(())
+    crate::wait_child(&mut open, "xdg-open")
 }
 
 fn open_with_wslview(path: &OsStr) -> io::Result<Child> {

--- a/opener/tests/missing_file.rs
+++ b/opener/tests/missing_file.rs
@@ -1,0 +1,8 @@
+use opener::open;
+
+// If we try to open a non-existant path, opener should return some
+// kind of error
+#[test]
+fn test_missing_file() {
+    assert!(open("non_existant_path").is_err());
+}


### PR DESCRIPTION
MacOS, Windows and WSL wait for the open child process to exit, and checks its exit code. This means that errors in the opening process are returned to the user. However, the linux implementation does not wait for the xdg-open process to exit. This means that potential errors returned by xdg-open are ignored.

This fixes the code by making the linux implementation also wait for the child process to exit, and checking its return type.