### PR TITLE
Replace winapi dependency with windows

### DIFF
--- a/opener/Cargo.toml
+++ b/opener/Cargo.toml
@@ -19,8 +19,8 @@ maintenance = { status = "passively-maintained" }
 reveal = [
     "dep:url",
     "dep:dbus",
-    "winapi/shtypes",
-    "winapi/objbase",
+    "windows/Win32_System_Com",
+    "windows/Win32_UI_Shell_Common"
 ]
 
 [dev-dependencies]
@@ -33,7 +33,11 @@ url = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 normpath = "1"
-winapi = { version = "0.3", features = ["shellapi"] }
+windows = { version = "0", features = [
+  "Win32_Foundation",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging"
+] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opener/Cargo.toml
+++ b/opener/Cargo.toml
@@ -17,10 +17,10 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 reveal = [
-    "dep:url",
-    "dep:dbus",
-    "windows/Win32_System_Com",
-    "windows/Win32_UI_Shell_Common"
+  "dep:url",
+  "dep:dbus",
+  "windows/Win32_System_Com",
+  "windows/Win32_UI_Shell_Common",
 ]
 
 [dev-dependencies]
@@ -33,10 +33,10 @@ url = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 normpath = "1"
-windows = { version = "0", features = [
+windows = { version = "0.52", features = [
   "Win32_Foundation",
   "Win32_UI_Shell",
-  "Win32_UI_WindowsAndMessaging"
+  "Win32_UI_WindowsAndMessaging",
 ] }
 
 [package.metadata.docs.rs]

--- a/opener/src/windows.rs
+++ b/opener/src/windows.rs
@@ -1,11 +1,13 @@
 use crate::OpenError;
 use normpath::PathExt;
 use std::ffi::OsStr;
+use std::io;
 use std::os::windows::ffi::OsStrExt;
 use std::path::PathBuf;
-use std::{io, ptr};
-use winapi::ctypes::c_int;
-use winapi::um::shellapi::ShellExecuteW;
+use windows::core::{w, PCWSTR};
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::Shell::ShellExecuteW;
+use windows::Win32::UI::WindowsAndMessaging::SW_SHOW;
 
 #[cfg(feature = "reveal")]
 mod reveal;
@@ -27,21 +29,18 @@ pub(crate) fn open(path: &OsStr) -> Result<(), OpenError> {
 }
 
 pub(crate) fn open_helper(path: &OsStr) -> Result<(), OpenError> {
-    const SW_SHOW: c_int = 5;
-
     let path = convert_path(path).map_err(OpenError::Io)?;
-    let operation: Vec<u16> = OsStr::new("open\0").encode_wide().collect();
     let result = unsafe {
         ShellExecuteW(
-            ptr::null_mut(),
-            operation.as_ptr(),
-            path.as_ptr(),
-            ptr::null(),
-            ptr::null(),
+            HWND(0),
+            w!("open"),
+            PCWSTR::from_raw(path.as_ptr()),
+            PCWSTR::null(),
+            PCWSTR::null(),
             SW_SHOW,
         )
     };
-    if result as c_int > 32 {
+    if result.0 > 32 {
         Ok(())
     } else {
         Err(OpenError::Io(io::Error::last_os_error()))


### PR DESCRIPTION
Since normpath was [added][1], opener has depended on both winapi (directly) and windows-sys (transitively).

This commit replaces usage of winapi with the windows crate so that it only depends on a single windows API crate. Additionally, the windows crate includes some functions that were manually linked in opener, so those manual links were able to be cleaned up.

[1]: https://github.com/Seeker14491/opener/commit/3b48ee084300ba883bed11259d978fa989ffaed8

---

I'm not very experienced with unsafe Rust 😅. Any feedback is appreciated!