### PR TITLE
Workaround for https://github.com/rust-lang/cargo/issues/10788

### DIFF
--- a/opener/Cargo.toml
+++ b/opener/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "passively-maintained" }
 [features]
 default = ["dbus-vendored"]
 reveal = ["dep:url", "dep:dbus", "windows-sys/Win32_System_Com"]
-dbus-vendored = ["dbus/vendored"]
+dbus-vendored = ["dbus?/vendored"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bstr = "1"


### PR DESCRIPTION
As described in Cargo Issue 10788, until Rust 1.71 there were cases where the dependency/feature syntax would not work correctly when used in combination with the dep:dependency syntax. Workarounds include adding an explicit feature

dependency = ["dep:dependency"]

but in many (most?) cases it is enough to only enable the dependency feature if the dependency is already enabled, via the dependency?/feature syntax.

For context, here are some workarounds employed by others:
- https://github.com/mstange/samply/commit/89456d46720217ecd24b451ffdaf358d67d60a1d
- https://github.com/alexrudy/tonic/commit/f3869543f8dd183428c5f476b335e2c5b3032c64
- https://github.com/jwodder/confab/commit/6f0e2fc3ee012a99b44ba9b16415c38de8d495ed