### PR TITLE
Update windows-sys to 0.59

### DIFF
--- a/opener/Cargo.toml
+++ b/opener/Cargo.toml
@@ -25,7 +25,7 @@ url = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 normpath = "1"
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",

--- a/opener/src/windows.rs
+++ b/opener/src/windows.rs
@@ -31,7 +31,7 @@ pub(crate) fn open_helper(path: &OsStr) -> Result<(), OpenError> {
     let operation: Vec<u16> = OsStr::new("open\0").encode_wide().collect();
     let result = unsafe {
         ShellExecuteW(
-            0,
+            ptr::null_mut(),
             operation.as_ptr(),
             path.as_ptr(),
             ptr::null(),
@@ -39,7 +39,7 @@ pub(crate) fn open_helper(path: &OsStr) -> Result<(), OpenError> {
             SW_SHOW,
         )
     };
-    if result > 32 {
+    if result as usize as isize > 32 {
         Ok(())
     } else {
         Err(OpenError::Io(io::Error::last_os_error()))


### PR DESCRIPTION
The notable change is that the first argument and return value of ShellExecuteW has changed from isize to pointer (https://github.com/microsoft/windows-rs/pull/3111).
- https://docs.rs/windows-sys/0.59.0/windows_sys/Win32/UI/Shell/fn.ShellExecuteW.html
- https://docs.rs/windows-sys/0.52.0/windows_sys/Win32/UI/Shell/fn.ShellExecuteW.html